### PR TITLE
Add support for DD_HOSTNAME

### DIFF
--- a/lib/OpenTracing/Implementation/DataDog/Client.pm
+++ b/lib/OpenTracing/Implementation/DataDog/Client.pm
@@ -264,6 +264,8 @@ a hashreference with the following keys:
 
 =item C<env> (optional)
 
+=item C<hostname> (optional)
+
 =item C<name>
 
 =item C<start>
@@ -314,6 +316,9 @@ sub to_struct {
         
         maybe
         env       => $context->get_environment,
+        
+        maybe
+        hostname  => $context->get_hostname,
         
         name      => $span->get_operation_name,
         start     => nano_seconds( $span->start_time() ),

--- a/lib/OpenTracing/Implementation/DataDog/SpanContext.pm
+++ b/lib/OpenTracing/Implementation/DataDog/SpanContext.pm
@@ -18,6 +18,7 @@ our $VERSION = 'v0.43.2';
         service_type  => "web",
         resource_name => "/clients/{client_id}/contactdetails",
         environment   => 'staging',
+        hostname      => 'web.01.host',
     );
     #
     # please do not add parameter values in the resource,
@@ -163,6 +164,23 @@ has environment => (
     required        => 0,
     env_key         => 'DD_ENV',
     reader          => 'get_environment',
+    trigger         => Lock,
+);
+
+
+
+=head2 C<hostname>
+
+An optional C<NonEmptyString> where C<length <= 5000>.
+
+=cut
+
+has hostname => (
+    is              => 'ro',
+    should          => NonEmptyStr->where( 'length($_) <= 5000' ),
+    required        => 0,
+    env_key         => 'DD_HOSTNAME',
+    reader          => 'get_hostname',
     trigger         => Lock,
 );
 
@@ -329,6 +347,32 @@ A cloned C<DataDog::SpanContext>
 =cut
 
 sub with_environment { $_[0]->clone_with( environment => $_[1] ) }
+
+
+
+=head2 C<with_hostname>
+
+Creates a cloned object, with a new value for C<hostname>.
+
+    $span_context_new = $root_span->with_hostname( 'web.01.host' );
+
+=head3 Required Positional Parameter(s)
+
+=over
+
+=item C<hostname>
+
+A C<NonEmptyString> where C<length <= 5000>.
+
+=back
+
+=head3 Returns
+
+A cloned C<DataDog::SpanContext>
+
+=cut
+
+sub with_hostname { $_[0]->clone_with( hostname => $_[1] ) }
 
 
 

--- a/lib/OpenTracing/Implementation/DataDog/Tracer.pm
+++ b/lib/OpenTracing/Implementation/DataDog/Tracer.pm
@@ -141,6 +141,14 @@ has default_environment => (
 
 
 
+has default_hostname => (
+    is          => 'ro',
+    should      => Str,
+    predicate   => 1,
+);
+
+
+
 sub build_span {
     my $self = shift;
     my %opts = @_;
@@ -188,6 +196,9 @@ sub build_context {
     my $environment   = delete $opts{ environment }
         || $self->default_environment;
     
+    my $hostname   = delete $opts{ hostname }
+        || $self->default_hostname;
+    
     my $span_context = SpanContext->new(
         
         %opts,
@@ -202,6 +213,9 @@ sub build_context {
         
         maybe
         environment     => $environment,
+        
+        maybe
+        hostname        => $hostname,
         
     );
     
@@ -231,6 +245,8 @@ sub inject_context_into_hash_reference   {
                 type          => $context->get_service_type,
                 maybe
                 environment   => $context->get_environment,
+                maybe
+                hostname      => $context->get_hostname,
             }
             
         }

--- a/t/OpenTracing/Implementation/DataDog/Client/11_to_struct.t
+++ b/t/OpenTracing/Implementation/DataDog/Client/11_to_struct.t
@@ -11,6 +11,7 @@ my $some_span_context = SpanContext->new(
     service_name    => 'srvc name',
     resource_name   => 'rsrc name',
     environment     => 'test envr',
+    hostname        => 'test host',
     baggage_items   => { foo => 1, bar => 2 },
 )->with_span_id(54365)->with_trace_id(87359);
 
@@ -37,6 +38,7 @@ cmp_deeply(
         service    => "srvc name",
         resource   => "rsrc name",
         env        => "test envr",
+        hostname   => 'test host',
         parent_id  => 54365,
         name       => "oprt name",
         start      => 52750000000, # nano seconds

--- a/t/OpenTracing/Implementation/DataDog/SpanContext/01_constructor_new.t
+++ b/t/OpenTracing/Implementation/DataDog/SpanContext/01_constructor_new.t
@@ -19,6 +19,7 @@ subtest 'new SpanContext with all parameters' => sub {
             resource_name => 'rsrc name',
             baggage_items => { foo => 1, bar => 2 },
             environment   => 'test envr',
+            hostname      => 'host name',
         )
     } "Created a SpanContext" ;
     
@@ -32,6 +33,7 @@ subtest 'new SpanContext with minimal parameters' => sub {
     
     local $ENV{ DD_SERVICE_NAME } = 'srvc dflt';
     local $ENV{ DD_ENV          } = 'test envr';
+    local $ENV{ DD_HOSTNAME     } = 'host dflt';
     
     lives_ok {
         $test_span_context = SpanContext->new(
@@ -51,6 +53,9 @@ subtest 'new SpanContext with minimal parameters' => sub {
     );
     is ( $test_span_context->get_environment, 'test envr',
         "... and default 'environment' has been set to DD_ENV"
+    );
+    is ( $test_span_context->get_hostname, 'host dflt',
+        "... and default 'hostname' has been set to DD_HOSTNAME"
     );
     
 };

--- a/t/OpenTracing/Implementation/DataDog/SpanContext/11_with_hostname.t
+++ b/t/OpenTracing/Implementation/DataDog/SpanContext/11_with_hostname.t
@@ -1,0 +1,46 @@
+use Test::Most;
+
+
+use aliased 'OpenTracing::Implementation::DataDog::SpanContext';
+
+
+
+subtest 'Clone with service_name' => sub {
+    
+    my $span_context_1;
+    my $span_context_2;
+    
+    lives_ok {
+        $span_context_1 = SpanContext->new(
+#           trace_id      => 12345, # you can not assign to trace_id!
+            service_name  => 'srvc 1',
+            resource_name => 'rsrc 1',
+            hostname      => 'host 1'
+            baggage_items => { foo => 1, bar => 2 },
+        )
+    } "Created a SpanContext [1]"
+    
+    or return;
+    
+    lives_ok {
+        $span_context_2 = $span_context_1->with_hostname('host 2');
+    } "... and cloned a new SpanContext [2]"
+    
+    or return;
+    
+    isnt $span_context_1, $span_context_2,
+    "... that is not the same object reference as the original";
+    
+    is $span_context_1->trace_id, $span_context_2->trace_id,
+        "... but has still the same 'trace_id'";
+    
+    is $span_context_1->get_hostname, 'host 1',
+        "... and the original SpanContext [1] has not changed";
+    
+    is $span_context_2->get_hostname, 'host 2',
+        "... and the cloned SpanContext [2] has the expected values [host 2]";
+    
+};
+
+
+done_testing;


### PR DESCRIPTION
Add support for this environment variable, which is useful when there is one single DataDog Trace Agent in a cluster.