### PR TITLE
Refactor `http_headers` and private methods

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -13,6 +13,7 @@ requires        "Moo::Role";
 requires        "MooX::Attribute::ENV", '>= 0.04';
 requires        "MooX::HandlesVia";
 requires        "MooX::Enumeration";
+requires        "MooX::ProtectedAttributes";
 requires        "MooX::Should", '>=v0.1.4';
 requires        "PerlX::Maybe";
 requires        "Ref::Util";

--- a/cpanfile
+++ b/cpanfile
@@ -13,6 +13,7 @@ requires        "Moo::Role";
 requires        "MooX::Attribute::ENV", '>= 0.04';
 requires        "MooX::HandlesVia";
 requires        "MooX::Enumeration";
+requires        "MooX::HandlesVia";
 requires        "MooX::ProtectedAttributes";
 requires        "MooX::Should", '>=v0.1.4';
 requires        "PerlX::Maybe";

--- a/t/OpenTracing/Implementation/DataDog/10_component.t
+++ b/t/OpenTracing/Implementation/DataDog/10_component.t
@@ -77,12 +77,12 @@ subtest "Check the requests" => sub {
     cmp_deeply(
         \@structs =>
         [
-            [[ superhashof { name => 'two'   } ]],
-            [[ superhashof { name => 'one_a' } ]],
-            [[ superhashof { name => 'two'   } ]],
-            [[ superhashof { name => 'two'   } ]],
-            [[ superhashof { name => 'one_b' } ]],
-            [[ superhashof { name => 'zero'  } ]],
+            [[ ( superhashof { name => 'two'   } ) ]],
+            [[ ( superhashof { name => 'one_a' } ) ]],
+            [[ ( superhashof { name => 'two'   } ) ]],
+            [[ ( superhashof { name => 'two'   } ) ]],
+            [[ ( superhashof { name => 'one_b' } ) ]],
+            [[ ( superhashof { name => 'zero'  } ) ]],
         ],
         "Got the right spans in the expected order"
     );

--- a/t/OpenTracing/Implementation/DataDog/Client/12_http_post_struct_as_json.t
+++ b/t/OpenTracing/Implementation/DataDog/Client/12_http_post_struct_as_json.t
@@ -57,6 +57,10 @@ subtest "Test a single request" => sub {
         "... and send the expected JSON";
     
     my $headers = $test_request->headers;
+    
+    is $headers->header('Datadog-Meta-Lang'), 'perl',
+        "... that contains the default Datadog-Meta-Lang [perl]";
+    
     is $headers->header('X-Datadog-Trace-Count'), 3,
         "... that contains the expected number of 'structs'";
     

--- a/t/OpenTracing/Implementation/DataDog/Client/12_http_post_struct_as_json.t
+++ b/t/OpenTracing/Implementation/DataDog/Client/12_http_post_struct_as_json.t
@@ -61,7 +61,7 @@ subtest "Test a single request" => sub {
     is $headers->header('Datadog-Meta-Lang'), 'perl',
         "... that contains the default Datadog-Meta-Lang [perl]";
     
-    is $headers->header('X-Datadog-Trace-Count'), 1, # we only send 1 TRACE
+    is $headers->header('X-Datadog-Trace-Count'), 3,
         "... that contains the expected number of 'structs'";
     
 };

--- a/t/OpenTracing/Implementation/DataDog/Client/12_http_post_struct_as_json.t
+++ b/t/OpenTracing/Implementation/DataDog/Client/12_http_post_struct_as_json.t
@@ -36,7 +36,7 @@ subtest "Test a single request" => sub {
     
     my $response;
     lives_ok {
-        $response = $datadog_client->http_post_struct_as_json(
+        $response = $datadog_client->_http_post_struct_as_json(
             [[ $struct1, $struct2, $struct3 ]]
         )
     } "Made a 'http_post_struct_as_json' call"
@@ -61,7 +61,7 @@ subtest "Test a single request" => sub {
     is $headers->header('Datadog-Meta-Lang'), 'perl',
         "... that contains the default Datadog-Meta-Lang [perl]";
     
-    is $headers->header('X-Datadog-Trace-Count'), 3,
+    is $headers->header('X-Datadog-Trace-Count'), 1, # we only send 1 TRACE
         "... that contains the expected number of 'structs'";
     
 };


### PR DESCRIPTION
For readability removed the `$headers` long list of cluttering HTTP Header Fields into a nice method.

Also, many methods have been made private, why would you want to mess with the internals of the `DataDog::Client`, the only thing it should expose is `send_span`, as that is required by the `DataDog::Tracer`.