### PR TITLE
Force ID fields to be numeric when JSON-encoded

### DIFF
--- a/lib/OpenTracing/Implementation/DataDog/Client.pm
+++ b/lib/OpenTracing/Implementation/DataDog/Client.pm
@@ -54,10 +54,8 @@ use Carp;
 use HTTP::Request ();
 use JSON::MaybeXS qw(JSON);
 use LWP::UserAgent;
-use Math::BigInt;
 use PerlX::Maybe qw/maybe provided/;
 use Regexp::Common qw/URI/;
-use Scalar::Util qw/blessed/;
 use Types::Standard qw/ArrayRef Bool Enum HasMethods Maybe Str/;
 use Types::Common::Numeric qw/IntRange/;
 
@@ -453,8 +451,8 @@ sub to_struct {
     if %meta_data;
     
     my $data = {
-        trace_id  => _cast_to_bigint($context->trace_id),
-        span_id   => _cast_to_bigint($context->span_id),
+        trace_id  => $context->trace_id,
+        span_id   => $context->span_id,
         resource  => $context->get_resource_name,
         service   => $context->get_service_name,
         
@@ -475,7 +473,7 @@ sub to_struct {
         duration  => nano_seconds( $span->duration() ),
         
         maybe
-        parent_id => _cast_to_bigint($span->get_parent_span_id()),
+        parent_id => $span->get_parent_span_id(),
         
         provided _is_with_errors( $span ),
         error     => 1,
@@ -770,20 +768,6 @@ sub _span_buffer_threshold_reached {
     
     return $self->_span_buffer_size >= $self->span_buffer_threshold
 }
-
-# _cast_to_bigint
-#
-# Returns the argument as a Math::BigInt object unless it is undef or already an object
-#
-sub _cast_to_bigint {
-    my $number = shift;
-
-    return unless defined $number;
-    return $number if blessed($number);
-
-    return Math::BigInt->new($number);
-}
-
 
 
 # DEMOLISH

--- a/lib/OpenTracing/Implementation/DataDog/Client.pm
+++ b/lib/OpenTracing/Implementation/DataDog/Client.pm
@@ -54,8 +54,10 @@ use Carp;
 use HTTP::Request ();
 use JSON::MaybeXS qw(JSON);
 use LWP::UserAgent;
+use Math::BigInt;
 use PerlX::Maybe qw/maybe provided/;
 use Regexp::Common qw/URI/;
+use Scalar::Util qw/blessed/;
 use Types::Standard qw/ArrayRef Bool Enum HasMethods Maybe Str/;
 use Types::Common::Numeric qw/IntRange/;
 
@@ -437,7 +439,7 @@ sub to_struct {
     my $span = shift;
     
     my $context = $span->get_context();
-    
+
     my %meta_data = (
         _fixup_span_tags( $span->get_tags ),
         $context->get_baggage_items,
@@ -451,8 +453,8 @@ sub to_struct {
     if %meta_data;
     
     my $data = {
-        trace_id  => $context->trace_id,
-        span_id   => $context->span_id,
+        trace_id  => _cast_to_bigint($context->trace_id),
+        span_id   => _cast_to_bigint($context->span_id),
         resource  => $context->get_resource_name,
         service   => $context->get_service_name,
         
@@ -473,7 +475,7 @@ sub to_struct {
         duration  => nano_seconds( $span->duration() ),
         
         maybe
-        parent_id => $span->get_parent_span_id(),
+        parent_id => _cast_to_bigint($span->get_parent_span_id()),
         
         provided _is_with_errors( $span ),
         error     => 1,
@@ -767,6 +769,19 @@ sub _span_buffer_threshold_reached {
     my $self = shift;
     
     return $self->_span_buffer_size >= $self->span_buffer_threshold
+}
+
+# _cast_to_bigint
+#
+# Returns the argument as a Math::BigInt object unless it is undef or already an object
+#
+sub _cast_to_bigint {
+    my $number = shift;
+
+    return unless defined $number;
+    return $number if blessed($number);
+
+    return Math::BigInt->new($number);
 }
 
 

--- a/lib/OpenTracing/Implementation/DataDog/SpanContext.pm
+++ b/lib/OpenTracing/Implementation/DataDog/SpanContext.pm
@@ -38,9 +38,12 @@ use OpenTracing::Implementation::DataDog::Utils qw/random_bigint/;
 
 use Sub::Trigger::Lock;
 use Types::Common::String qw/NonEmptyStr/;
-use Types::Standard qw/InstanceOf Maybe/;
+use Types::Standard qw/Any InstanceOf Maybe/;
 
 
+my $BigInt = (InstanceOf['Math::BigInt'])->plus_coercions(
+    Any, sub { Math::BigInt->new($_) },
+);
 
 =head1 DESCRIPTION
 
@@ -59,30 +62,40 @@ compliant implementation with DataDog specific extentions
 
 =head2 C<trace_id>
 
-DataDog requires this to be a unsigned 64-bit integer
+DataDog requires this to be an unsigned 64-bit integer
 
 =cut
 
 has '+trace_id' => (
-    is =>'ro',
-    should => InstanceOf['Math::BigInt'],
-    default => sub{ random_bigint() }
+    is      =>'ro',
+    isa     => $BigInt,
+    coerce  => 1,
+    default => sub { random_bigint() },
 );
 
+around with_trace_id => sub {
+    my ($orig, $self, $id) = @_;
+    $orig->($self, $BigInt->coerce($id));
+};
 
 
 =head2 C<span_id>
 
-DataDog requires this to be a unsigned 64-bit integer
+DataDog requires this to be an unsigned 64-bit integer
 
 =cut
 
 has '+span_id' => (
-    is =>'ro',
-    should => InstanceOf['Math::BigInt'],
+    is      =>'ro',
+    isa     => $BigInt,
+    coerce  => 1,
     default => sub{ random_bigint() }
 );
 
+around with_span_id => sub {
+    my ($orig, $self, $id) = @_;
+    $orig->($self, $BigInt->coerce($id));
+};
 
 
 =head1 DATADOG SPECIFIC ATTRIBUTES

--- a/t/OpenTracing/Implementation/DataDog/Client/11_to_struct.t
+++ b/t/OpenTracing/Implementation/DataDog/Client/11_to_struct.t
@@ -33,15 +33,15 @@ my $struct = Client->new->to_struct( $test_span );
 
 cmp_deeply(
     $struct => {
-        trace_id   => 87359,
-        span_id    => 49603,
+        trace_id   => Math::BigInt->new(87359),
+        span_id    => Math::BigInt->new(49603),
         type       => "custom",
         service    => "srvc name",
         resource   => "rsrc name",
         env        => "test envr",
         hostname   => 'test host',
         version    => 'test vers',
-        parent_id  => 54365,
+        parent_id  => Math::BigInt->new(54365),
         name       => "oprt name",
         start      => 52750000000, # nano seconds
         duration   => 30750000000, # nano seconds


### PR DESCRIPTION
The DataDog agent requires all ID fields to be properly numeric (they can't be quoted as strings, even if the content is only numbers). This change converts the ID fields into Math::BigInt unless they are already objects (if they are objects, they either are already Math::BigInt or should handle serialization on their own).